### PR TITLE
ci: Node.js v18 designation

### DIFF
--- a/apps/kporg-backend/package.json
+++ b/apps/kporg-backend/package.json
@@ -21,5 +21,8 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "gray-matter": "^4.0.3"
+  },
+  "engines": {
+    "node": "18.x"
   }
 }

--- a/apps/kporg-frontend/package.json
+++ b/apps/kporg-frontend/package.json
@@ -32,5 +32,8 @@
     "remark-rehype": "^10.1.0",
     "unified": "^10.1.2"
   },
-  "license": "MPL-2.0"
+  "license": "MPL-2.0",
+  "engines": {
+    "node": "18.x"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
         "frontend.ci": "yarn licenses.generate && yarn frontend.build",
         "licenses.generate": "yarn licenses generate-disclaimer > apps/kporg-frontend/public/licenses.txt"
     },
-    "license": "MPL-2.0"
+    "license": "MPL-2.0",
+    "engines": {
+      "node": "18.x"
+    }
 }


### PR DESCRIPTION
This PR migrates Node.js for SSG environment to v18.

Cloudflare Pages does not support Node v18 for now (maybe because of old OS), so running on Azure.
