### PR TITLE
ci: Update checkout action for Azure CI

### DIFF
--- a/.github/workflows/azure-static-web-apps-black-bay-0bbeafc00.yml
+++ b/.github/workflows/azure-static-web-apps-black-bay-0bbeafc00.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Build And Deploy


### PR DESCRIPTION
This is to remove warning messages from GitHub Actions.
